### PR TITLE
Updated go.mod to effectively rehome the repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ess/cronenberg
+module github.com/starkandwayne/cronenberg
 
 require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1


### PR DESCRIPTION
This is primarily for the purposes of hard forking cronenberg in case the original author doesn't want the modifications we may need to make. Also makes the imports a bit cleaner within the project that treats this as a dependency.